### PR TITLE
WIP: Update AWS SDK Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 		<maven.plugin.api.version>3.0.5</maven.plugin.api.version>
 		<plexus.utils.version>3.0.1</plexus.utils.version>
 		<commons.codec.version>1.6</commons.codec.version>
-		<aws.sdk.version>1.4.6</aws.sdk.version>
+		<aws.sdk.version>1.11.519</aws.sdk.version>
 		<junit.version>4.10</junit.version>
 		<mockito.version>1.9.0</mockito.version>
 


### PR DESCRIPTION
Some AWS regions already require support for Signature Version 4.

Using 1.1 version of this plugin we get the following error:

`Failed to execute goal io.pst.mojo:s3-static-uploader-plugin:1.1:upload (default-cli) on project
......
The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256`

1.11.519 version of aws-java-sdk plugin resolves the problem.